### PR TITLE
Fix compatibility with symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "name":"Gintautas Miselis"
         }
     ],
+    "require": {
+        "symfony/browser-kit": "^5.2 || ^6.0 || ^7.0 || ^8.0"
+    },
     "minimum-stability": "RC",
 
     "autoload":{

--- a/src/Codeception/Lib/Connector/Universal.php
+++ b/src/Codeception/Lib/Connector/Universal.php
@@ -4,7 +4,7 @@ namespace Codeception\Lib\Connector;
 use Symfony\Component\BrowserKit\AbstractBrowser as Client;
 use Symfony\Component\BrowserKit\Response;
 
-class Universal extends Client
+final class Universal extends Client
 {
     use Shared\PhpSuperGlobalsConverter;
 

--- a/src/Codeception/Lib/Connector/Universal.php
+++ b/src/Codeception/Lib/Connector/Universal.php
@@ -21,7 +21,7 @@ class Universal extends Client
         $this->mockedResponse = $response;
     }
 
-    public function doRequest($request)
+    public function doRequest(object $request): object
     {
         if ($this->mockedResponse) {
             $response = $this->mockedResponse;


### PR DESCRIPTION
Symfony 8 uses native type hints in `AbstractBrowser::doRequest()`.

This PR is a blocker for ensuring symfony 8 compatibility in various other codeception packages.